### PR TITLE
util/gpu_t.cuh: replace vec_t with slice_t [and drop pin_t].

### DIFF
--- a/msm/pippenger.cuh
+++ b/msm/pippenger.cuh
@@ -10,6 +10,7 @@
 #include <cassert>
 
 #include <util/vec2d_t.hpp>
+#include <util/slice_t.hpp>
 
 #include "sort.cuh"
 #include "batch_addition.cuh"
@@ -336,6 +337,8 @@ class msm_t {
     affine_h *d_points;
     scalar_t *d_scalars;
     vec2d_t<uint32_t> d_hist;
+
+    template<typename T> using vec_t = slice_t<T>;
 
     class result_t {
         bucket_t ret[MSM_NTHREADS/bucket_t::degree][2];
@@ -709,7 +712,7 @@ RustError mult_pippenger(point_t *out, const affine_t points[], size_t npoints,
 {
     try {
         msm_t<bucket_t, point_t, affine_t, scalar_t> msm{nullptr, npoints};
-        return msm.invoke(*out, vec_t<affine_t>{points, npoints},
+        return msm.invoke(*out, slice_t<affine_t>{points, npoints},
                                 scalars, mont, ffi_affine_sz);
     } catch (const cuda_error& e) {
         out->inf();

--- a/msm/pippenger.hpp
+++ b/msm/pippenger.hpp
@@ -359,4 +359,17 @@ static void mult_pippenger(point_t& ret, const std::vector<affine_t>& points,
                                   std::min(points.size(), scalars.size()),
                                   scalars.data(), mont, da_pool);
 }
+
+#include <util/slice_t.hpp>
+
+template <class bucket_t, class point_t, class scalar_t,
+          class affine_t = class bucket_t::affine_t>
+static void mult_pippenger(point_t& ret, slice_t<affine_t> points,
+                           slice_t<scalar_t> scalars, bool mont,
+                           thread_pool_t* da_pool = nullptr)
+{
+    mult_pippenger<bucket_t>(ret, points.data(),
+                                  std::min(points.size(), scalars.size()),
+                                  scalars.data(), mont, da_pool);
+}
 #endif

--- a/util/slice_t.hpp
+++ b/util/slice_t.hpp
@@ -1,0 +1,43 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __SPPARK_UTIL_SLICE_T_HPP__
+#define __SPPARK_UTIL_SLICE_T_HPP__
+
+#include <vector>
+
+#ifdef __CUDACC__
+# ifdef inline
+#  define slice_t_saved_inline inline
+#  undef inline
+# endif
+# define inline inline __host__ __device__
+#endif
+
+// A simple way to pack a constant pointer and array's size length,
+// and to "borrow" std::vector<T>&...
+template<typename T> class slice_t {
+    const T* ptr;
+    size_t nelems;
+public:
+    slice_t() : ptr(nullptr), nelems(0)                                 {}
+    slice_t(void* p, size_t n) : ptr(reinterpret_cast<T*>(p)), nelems(n){}
+    slice_t(const T* p, size_t n) : ptr(p), nelems(n)                   {}
+    slice_t(const std::vector<T>& v) : ptr(v.data()), nelems(v.size())  {}
+
+    inline operator void*() const               { return (void*)ptr; }
+    inline operator decltype(ptr)() const       { return ptr; }
+    inline const T* data() const                { return ptr; }
+    inline size_t size() const                  { return nelems; }
+    inline const T& operator[](size_t i) const  { return ptr[i]; }
+};
+
+#ifdef __CUDACC__
+# undef inline
+# ifdef slice_t_saved_inline
+#  define inline slice_t_saved_inline
+# endif
+#endif
+
+#endif


### PR DESCRIPTION
As for pin_t. It was intended to pin memory for a call duration, but it turned to be effectively meaningless, because pinning itself is more expensive than data transfer from unpinned memory.

This has to be synchronized with https://github.com/supranational/supra_seal/pull/20.
