### PR TITLE
Make Go bridge work on Windows.

### DIFF
--- a/go/cgo_sppark.h
+++ b/go/cgo_sppark.h
@@ -11,7 +11,9 @@ typedef struct {
     _GoString_ message;
 } GoError;
 
+#ifndef _WIN32
 __attribute__((weak))   // required with go1.18 and earlier
+#endif
 void toGoError(GoError *go_err, Error c_err);
 
 #define WRAP_ERR(ret_t, func, ...) __attribute__((section("_sppark"), used)) \

--- a/ntt/parameters.cuh
+++ b/ntt/parameters.cuh
@@ -249,22 +249,21 @@ public:
     ~NTTParameters()
     {
         int current_id;
-        cudaGetDevice(&current_id);
+        if (cudaGetDevice(&current_id) != cudaSuccess) {
+            gpu.select();
 
-        gpu.select();
-        gpu.Dfree(partial_twiddles);
-
+            (void)cudaFreeAsync(partial_twiddles, gpu);
 #if !defined(FEATURE_BABY_BEAR) && !defined(FEATURE_GOLDILOCKS)
-        gpu.Dfree(radix9_twiddles_9);
-        gpu.Dfree(radix8_twiddles_8);
-        gpu.Dfree(radix7_twiddles_7);
-        gpu.Dfree(radix6_twiddles_12);
-        gpu.Dfree(radix6_twiddles_6);
+            (void)cudaFreeAsync(radix9_twiddles_9, gpu);
+            (void)cudaFreeAsync(radix8_twiddles_8, gpu);
+            (void)cudaFreeAsync(radix7_twiddles_7, gpu);
+            (void)cudaFreeAsync(radix6_twiddles_12, gpu);
+            (void)cudaFreeAsync(radix6_twiddles_6, gpu);
 #endif
+            (void)cudaFreeAsync(twiddles[1], gpu);
 
-        gpu.Dfree(twiddles[1]);
-
-        cudaSetDevice(current_id);
+            cudaSetDevice(current_id);
+        }
     }
 
     inline void sync() const    { gpu.sync(); }

--- a/poc/go/cgo_sppark.h
+++ b/poc/go/cgo_sppark.h
@@ -11,7 +11,9 @@ typedef struct {
     _GoString_ message;
 } GoError;
 
+#ifndef _WIN32
 __attribute__((weak))   // required with go1.18 and earlier
+#endif
 void toGoError(GoError *go_err, Error c_err);
 
 #define WRAP_ERR(ret_t, func, ...) __attribute__((section("_sppark"), used)) \

--- a/poc/go/poc.cu
+++ b/poc/go/poc.cu
@@ -1,5 +1,8 @@
 #include <stdio.h>
 #include <string.h>
+#ifdef _MSC_VER
+# define strdup _strdup
+#endif
 
 __global__ void kernel()
 {

--- a/poc/ntt-cuda/go/cgo_sppark.h
+++ b/poc/ntt-cuda/go/cgo_sppark.h
@@ -11,7 +11,9 @@ typedef struct {
     _GoString_ message;
 } GoError;
 
+#ifndef _WIN32
 __attribute__((weak))   // required with go1.18 and earlier
+#endif
 void toGoError(GoError *go_err, Error c_err);
 
 #define WRAP_ERR(ret_t, func, ...) __attribute__((section("_sppark"), used)) \

--- a/poc/ntt-cuda/go/goldilocks.go
+++ b/poc/ntt-cuda/go/goldilocks.go
@@ -40,7 +40,7 @@ func NTT(device_id int, inout []uint64,
 
     var err C.GoError
     C.go_compute_ntt(&err, C.size_t(device_id),
-                           (*C.ulong)(&inout[0]), C.uint(lgDomainSz),
+                           (*C.uint64_t)(&inout[0]), C.uint(lgDomainSz),
                            order, direction, kind)
     if err.code != 0 {
         panic(err.message)

--- a/util/all_gpus.cpp
+++ b/util/all_gpus.cpp
@@ -71,3 +71,8 @@ SPPARK_FFI gpu_ptr_t<void>::by_value clone_gpu_ptr_t(const gpu_ptr_t<void>& rhs)
 #ifdef __clang__
 # pragma clang diagnostic pop
 #endif
+
+#ifdef TAKE_RESPONSIBILITY_FOR_ERROR_MESSAGE
+SPPARK_FFI void drop_error_message(char *ptr)
+{   free(ptr);   }
+#endif


### PR DESCRIPTION
@sandsentinel, could you test this on Windows? As mentioned, annoyingly enough one needs three compilers on the %PATH%, nvcc, cl and **mingw**[!] gcc, by the time `go test` is executed. As for the gcc, consider [tdm-gcc](https://jmeubank.github.io/tdm-gcc/). I'm not using it myself, I'm using one that is available with msys2, but tdm should work.