### PR TITLE
Fix typographical errors

### DIFF
--- a/msm/sort.cuh
+++ b/msm/sort.cuh
@@ -18,7 +18,7 @@
 #endif
 
 __launch_bounds__(SORT_BLOCKDIM)
-__global__ void sort(vec2d_t<uint32_t> inouts, size_t len, uint32_t win,
+__global__ void sort(vec2d_t<uint32_t> inputs, size_t len, uint32_t win,
                      vec2d_t<uint2> temps, vec2d_t<uint32_t> histograms,
                      uint32_t wbits, uint32_t lsbits0, uint32_t lsbits1);
 
@@ -364,12 +364,12 @@ __global__ void sort(uint32_t inout[], size_t len, uint2 temp[],
 #endif
 
 __launch_bounds__(SORT_BLOCKDIM)
-__global__ void sort(vec2d_t<uint32_t> inouts, size_t len, uint32_t win,
+__global__ void sort(vec2d_t<uint32_t> inputs, size_t len, uint32_t win,
                      vec2d_t<uint2> temps, vec2d_t<uint32_t> histograms,
                      uint32_t wbits, uint32_t lsbits0, uint32_t lsbits1)
 {
     win += blockIdx.y;
-    sort_row(inouts[win], len, temps[blockIdx.y], histograms[win],
+    sort_row(inputs[win], len, temps[blockIdx.y], histograms[win],
              wbits, blockIdx.y==0 ? lsbits0 : lsbits1);
 }
 

--- a/ntt/kernels.cu
+++ b/ntt/kernels.cu
@@ -59,7 +59,7 @@ template<unsigned int Z_COUNT, class fr_t>
 __launch_bounds__(192, 2) __global__
 void bit_rev_permutation_z(fr_t* out, const fr_t* in, uint32_t lg_domain_size)
 {
-    static_assert((Z_COUNT & (Z_COUNT-1)) == 0, "unvalid Z_COUNT");
+    static_assert((Z_COUNT & (Z_COUNT-1)) == 0, "invalid Z_COUNT");
     const uint32_t LG_Z_COUNT = lg2(Z_COUNT);
 
     extern __shared__ int xchg_bit_rev[];


### PR DESCRIPTION
1. **In `kernels.cu`**:
   - "unvalid" corrected to "invalid" in the static assertion.

2. **In `sort.cuh`**:
   - "inouts" corrected to "inputs" in function parameters and function calls.
   - Other related spelling adjustments were made to ensure consistency in function definitions.
