### PR TITLE
Fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sppark
 
-sppark (pronounced 'spark') is **S**upranational's **p**erformance **p**primitives for **ar**guments of **k**nowledge such as SNARKs and STARKs. The library focuses on accelerating the most computationally expensive pieces of zero-knowledge proofs generation such as multi-scalar multiplication (MSM), number theoretic transform (NTT), arithmetic hashes, and more. The library is a collection of CUDA/C++ templates that can be instantiated for a range of finite fields and elliptic curves.
+sppark (pronounced 'spark') is **S**upranational's **p**erformance **p**pprimitives for **ar**guments of **k**nowledge such as SNARKs and STARKs. The library focuses on accelerating the most computationally expensive pieces of zero-knowledge proofs generation such as multi-scalar multiplication (MSM), number theoretic transform (NTT), arithmetic hashes, and more. The library is a collection of CUDA/C++ templates that can be instantiated for a range of finite fields and elliptic curves.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sppark
 
-sppark (pronounced 'spark') is **S**upranational's **p**erformance **p**rimitives for **ar**guments of **k**nowledge such as SNARKs and STARKs. The library focuses on accelerating the most computationally expensive pieces of zero-knowledge proofs generation such as multi-scalar multiplication (MSM), number theoretic transform (NTT), arithmetic hashes, and more. The library is a collection of CUDA/C++ templates that can be instantiated for a range of finite fields and elliptic curves.
+sppark (pronounced 'spark') is **S**upranational's **p**erformance **p**primitives for **ar**guments of **k**nowledge such as SNARKs and STARKs. The library focuses on accelerating the most computationally expensive pieces of zero-knowledge proofs generation such as multi-scalar multiplication (MSM), number theoretic transform (NTT), arithmetic hashes, and more. The library is a collection of CUDA/C++ templates that can be instantiated for a range of finite fields and elliptic curves.
 
 ## Table of Contents
 

--- a/poc/ntt-cuda/go/goldilocks.go
+++ b/poc/ntt-cuda/go/goldilocks.go
@@ -8,10 +8,10 @@ package goldilocks
 // typedef enum { standard, coset  } Type;
 //
 // WRAP_ERR(Error, compute_ntt, size_t device_id,
-//                              uint64_t inout[], uint32_t lg_domain_size,
+//                              uint64_t input, in out[], uint32_t lg_domain_size,
 //                              InputOutputOrder order, Direction direction,
 //                              Type type)
-// {   toGoError(go_err, (*compute_ntt.call)(device_id, inout, lg_domain_size,
+// {   toGoError(go_err, (*compute_ntt.call)(device_id, input, in out, lg_domain_size,
 //                                           order, direction, type));
 // }
 import "C"
@@ -25,22 +25,22 @@ func init() {
     sppark.Load("../cuda/ntt_api.cu", "-O2", "-DFEATURE_GOLDILOCKS")
 }
 
-func NTT(device_id int, inout []uint64,
+func NTT(device_id int, input, in out []uint64,
          order InputOutputOrder, direction Direction, optional ...Type) {
     kind := Standard
     if len(optional) > 0 {
         kind = optional[0]
     }
 
-    domainSz := len(inout)
+    domainSz := len(input, in out)
     if (domainSz & (domainSz-1)) != 0 {
-        panic("invalid |inout| size")
+        panic("invalid |input, in out| size")
     }
     lgDomainSz := bits.Len(uint(domainSz)) - 1
 
     var err C.GoError
     C.go_compute_ntt(&err, C.size_t(device_id),
-                           (*C.uint64_t)(&inout[0]), C.uint(lgDomainSz),
+                           (*C.uint64_t)(&input, in out[0]), C.uint(lgDomainSz),
                            order, direction, kind)
     if err.code != 0 {
         panic(err.message)


### PR DESCRIPTION
### Changes

1. **File:** `/README.md`
    - Fixed `rimitives` to `primitives` (Line 3)
1. **File:** `/poc/ntt-cuda/go/goldilocks.go`
    - Fixed `inout` to `input, in out` (Line 28)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.