### PR TITLE
util/gpu_t.cuh: track allocating stream in gpu_ptr_t for correct cudaFreeAsync

### DIFF
--- a/util/gpu_t.cuh
+++ b/util/gpu_t.cuh
@@ -271,13 +271,16 @@ template<typename T> class gpu_ptr_t {
         T* ptr;
         std::atomic<size_t> ref_cnt;
         int real_id;
-        inline inner(T* p) : ptr(p), ref_cnt(1)
+        cudaStream_t stream;
+        inline inner(T* p, cudaStream_t s = nullptr)
+            : ptr(p), ref_cnt(1), stream(s)
         {   (void)cudaGetDevice(&real_id);   }
     };
     inner *ptr;
 public:
     gpu_ptr_t() : ptr(nullptr)    {}
     gpu_ptr_t(T* p)               { ptr = new inner(p); }
+    gpu_ptr_t(T* p, cudaStream_t s) { ptr = new inner(p, s); }
     gpu_ptr_t(const gpu_ptr_t& r) { *this = r; }
     ~gpu_ptr_t()
     {
@@ -286,7 +289,10 @@ public:
             (void)cudaGetDevice(&current_id);
             if (current_id != ptr->real_id)
                 (void)cudaSetDevice(ptr->real_id);
-            (void)cudaFreeAsync(ptr->ptr, nullptr);
+            if (ptr->stream)
+                (void)cudaFreeAsync(ptr->ptr, ptr->stream);
+            else
+                (void)cudaFree(ptr->ptr);
             if (current_id != ptr->real_id)
                 (void)cudaSetDevice(current_id);
             delete ptr;


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lotus/issues/13634

e26423e introduced the switch from `cudaFree(ptr->ptr)` to `cudaFreeAsync(ptr->ptr, nullptr)`. My understanding is that `nullptr` here makes it operate on the legacy default stream, which isn't used anywhere in the codebase, callers use explicit streams everywhere else, so `cudaFreeAsync` never does its work and we get a leak. This manifests downstream as progressively pinned GPU memory in long-lived processes, Lotus (Filecoin) has been seeing OOMs in seal-commit-phase-2 and WindowPoSt because of it.

This change adds a `cudaStream_t` field to `gpu_ptr_t::inner` and a new 2-arg constructor `gpu_ptr_t(T*, cudaStream_t)` for wrapping pointers from `cudaMallocAsync`. The destructor uses `cudaFreeAsync` against the stored stream when set, falling back to `cudaFree` for the existing 1-arg constructor. The 1-arg is left for backward compatibility but there aren't any callers in here that really need it so it could be removed, any other callers outside of here are going to need the 2-arg to benefit from the fix (which might argue for removing 1-arg).

Verified with `cargo test --release --features bls12_381` in both poc/ntt-cuda and poc/msm-cuda against v0.1.14 + this patch.